### PR TITLE
Update deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/slackpad/venn
 
-go 1.24.0
+go 1.26
 
-toolchain go1.24.7
+toolchain go1.26.2
 
 require (
 	github.com/cheggaaa/pb/v3 v3.1.7


### PR DESCRIPTION
# Update deps — code notes

## Result

Bump is effectively a no-op for the dependency graph. Only the Go toolchain lines in `go.mod` changed; every direct dep was already pinned at its latest release and none has a newer major available. Build and tests pass.

## Diff

```
 go.mod | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

```diff
-go 1.24.0
+go 1.26

-toolchain go1.24.7
+toolchain go1.26.2
```

`go.sum` is unchanged. No source files touched.

## What was checked

Ran `go get <module>@latest` for each direct dep; all were no-ops against the versions already in `go.mod`:

| Dep | Version (unchanged) | Latest available |
|---|---|---|
| `github.com/cheggaaa/pb/v3` | `v3.1.7` | `v3.1.7` (no `/v4`) |
| `github.com/hashicorp/go-hclog` | `v1.6.3` | `v1.6.3` |
| `github.com/mitchellh/cli` | `v1.1.5` | `v1.1.5` |
| `github.com/ryanuber/columnize` | `v2.1.2+incompatible` | `v2.1.2+incompatible` — still no go-modules-tagged release, left pinned as the spec anticipated |
| `go.etcd.io/bbolt` | `v1.4.3` | `v1.4.3` |

Version lists confirmed via `go list -m -versions <module>`. No major-version path (`/vN`) exists beyond what's already imported, so no call-site adjustments were needed.

## Verification

- `go build ./...` — clean, no output.
- `go test ./...` — `github.com/slackpad/venn/core` passes in ~0.74s; `venn` and `venn/cmd` have no test files. Suite remains under the 2s target.
- `go mod tidy` did fetch a few transitive test-dep archives into the module cache (`stretchr/testify`, `golang.org/x/sync`, `frankban/quicktest`, `kr/pretty`) but produced no changes to `go.mod` or `go.sum`.

## Acceptance check vs. spec

- [x] `go.mod` `go` / `toolchain` set to `1.26` / `go1.26.2` to match local toolchain (`go1.26.2 darwin/arm64`).
- [x] Direct deps refreshed to latest compatible releases (all already there).
- [x] `go mod tidy` run — no residual churn.
- [x] `go build ./...` succeeds.
- [x] `go test ./...` passes.
- [x] Behavior unchanged — zero source changes, only toolchain lines in `go.mod`.

## Notes for reviewer

- This request surfaced nothing to do beyond the Go version bump: the project was already current as of spec time, thanks in part to the earlier `golang.org/x/crypto v0.45.0` security bump on `master`.
- `ryanuber/columnize` remains on `+incompatible`; no upstream movement to a module-tagged release. Spec explicitly allowed leaving it.
- If you want a periodic refresh anyway, the natural next trigger is when any of these deps cuts a new release — nothing to do right now.
- (Trivial edit for harness testing — safe to revert.)
